### PR TITLE
添加测试任务过滤、添加未解锁建筑的物品需求

### DIFF
--- a/ModBehaviour.cs
+++ b/ModBehaviour.cs
@@ -155,6 +155,35 @@ namespace QuestItemRequirementsDisplay
                     Text.text += $"\n\t{entry.Amount}  -  {entry.PerkTreeName}/{entry.PerkName}";
                 }
             }
+
+            // Display buildings that require this item
+            var requiredBuildings = Utility.GetRequiredBuildings(item);
+            if (requiredBuildings.Count > 0)
+            {
+                switch (currentLanguage)
+                {
+                    case SystemLanguage.Chinese:
+                    case SystemLanguage.ChineseSimplified:
+                        Text.text += "\n需要该物品解锁的建筑:";
+                        break;
+                    case SystemLanguage.ChineseTraditional:
+                        Text.text += "\n需要該物品解鎖的建築:";
+                        break;
+                    case SystemLanguage.Japanese:
+                        Text.text += "\nこのアイテムが必要な建物:";
+                        break;
+                    case SystemLanguage.Korean:
+                        Text.text += "\n이아이템으로 해금이 필요한 건물:";
+                        break;
+                    default:
+                        Text.text += "\nBuildings required this item:";
+                        break;
+                }
+                foreach (var entry in requiredBuildings)
+                {
+                    Text.text += $"\n\t{entry.Amount}  -  {entry.BuildingName}";
+                }
+            }
         }
     }
 }

--- a/Utility.cs
+++ b/Utility.cs
@@ -1,6 +1,7 @@
 ﻿using Duckov.Quests;
 using Duckov.Quests.Tasks;
 using Duckov.Utilities;
+using Duckov.Buildings;
 using ItemStatsSystem;
 using System;
 using System.Collections.Generic;
@@ -12,8 +13,20 @@ namespace ballban
 {
     static public class Utility
     {
-        public static QuestCollection TotalQuests = GameplayDataSettings.QuestCollection;
+        public static List<Quest> TotalQuests = InitTotalQuests();
         public static QuestManager QuestMangaer = QuestManager.Instance;
+
+        private static List<Quest> InitTotalQuests()
+        {
+            var totalQuests = new List<Quest>(GameplayDataSettings.QuestCollection.Count);
+            foreach (var quest in GameplayDataSettings.QuestCollection)
+            {
+                if (IsTestingDisplayName(quest.DisplayName)) continue;
+                totalQuests.Add(quest);
+            }
+
+            return totalQuests;
+        }
 
         public struct RequiredPerk
         {
@@ -106,6 +119,11 @@ namespace ballban
             }
 
             return requiredSubmitItems;
+        }
+
+        private static bool IsTestingDisplayName(string name)
+        {
+            return name.StartsWith("*") && name.EndsWith("*");
         }
     }
 }

--- a/Utility.cs
+++ b/Utility.cs
@@ -28,6 +28,33 @@ namespace ballban
             return totalQuests;
         }
 
+        public struct RequiredBuilding
+        {
+            public long Amount;
+            public string BuildingName;
+        }
+
+        /// <summary>
+        /// Get a list of buildings that require the specified item to unlock.
+        /// WARNING: not UNLOCKED, but UNPLACED buildings
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        public static List<RequiredBuilding> GetRequiredBuildings(Item item)
+        {
+            return BuildingDataCollection.Instance.Infos
+                .Where(info =>
+                    info.CurrentAmount == 0 && !IsTestingDisplayName(info.DisplayName))
+                .SelectMany(info => info.cost.items
+                    .Where(itemEntry => itemEntry.id == item.TypeID)
+                    .Select(itemEntry => new RequiredBuilding
+                    {
+                        Amount = itemEntry.amount,
+                        BuildingName = info.DisplayName
+                    })
+                ).ToList();
+        }
+
         public struct RequiredPerk
         {
             public long Amount;


### PR DESCRIPTION
1. 过滤测试任务、测试建筑物 #1 
2. 增加未解锁建筑的物品需求（其实是未放置，但是没找到判断建筑是否未解锁……）