### PR TITLE
Feature: count equipped items & items inside nested slots

### DIFF
--- a/src/GetItemAmount.cs
+++ b/src/GetItemAmount.cs
@@ -67,6 +67,7 @@ namespace QuestItemRequirementsDisplay
         public static int GetTotalItemAmount(int typeID)
         {
             var totalAmount = InCharacterInventory(typeID)
+                            + InCharacterEquipment(typeID)
                             + InPetInventory(typeID)
                             + InPlayerStorage(typeID);
             return totalAmount;
@@ -82,6 +83,25 @@ namespace QuestItemRequirementsDisplay
             var inventory = LevelManager.Instance.MainCharacter.CharacterItem.Inventory;
             var amount = FromInventory(inventory, typeID);
             return amount;
+        }
+
+        /// <summary>
+        /// Get the total amount of the specified item type ID in the character's equipment.
+        /// </summary>
+        /// <param name="typeID"></param>
+        /// <returns></returns>
+        public static int InCharacterEquipment(int typeID)
+        {
+            var characterEquipments = LevelManager.Instance.MainCharacter.CharacterItem.Slots;
+            var inventory = new List<Item>();
+            foreach (var slot in characterEquipments)
+            {
+                if (slot?.Content != null)
+                {
+                    inventory.Add(slot.Content);
+                }
+            }
+            return FromInventory(inventory, typeID);
         }
 
         /// <summary>

--- a/src/ModBehaviour.cs
+++ b/src/ModBehaviour.cs
@@ -127,9 +127,7 @@ namespace QuestItemRequirementsDisplay
             }
 
             // Get total required item amount text
-            var itemAmountInCharacterInventory = GetItemAmount.InCharacterInventory(item.TypeID) + GetItemAmount.InPetInventory(item.TypeID);
-            var itemAmountInPlayerStorage = GetItemAmount.InPlayerStorage(item.TypeID);
-            var totalItemAmount = itemAmountInCharacterInventory + itemAmountInPlayerStorage;
+            var totalItemAmount = GetItemAmount.GetTotalItemAmount(item.TypeID);
 
             // Determine color based on whether the player has enough items
             var colorOfTotalitemAmount = totalItemAmount >= totalRequiredItemAmount ? "green" : "red";


### PR DESCRIPTION
## 1. 將角色裝備物品計入持有總量

### As-is

目前角色裝備物品不會計入持有總量，舉例來說:

- 裝備的鏟子未算入持有總量
![Eq_before](https://github.com/user-attachments/assets/7c0aa21d-afcf-4dc1-bfb2-6246f702bd5c)

### To-be

將角色裝備物品也計入持有總量，如下:

- 裝備的鏟子也算入持有總量
![Eq_after](https://github.com/user-attachments/assets/27561344-bf54-4517-8fd4-97faa27ac29f)

## 2. 將嵌套堆疊的容器內部的物品也算入持有總量

### As-is

目前只計算最外層物品欄位(Slot)內的物品量，舉例來說:

- "手提袋 > 藍色大桶 > 沙丁魚" 此處的沙丁魚數量未算入持有總量
![neat_before](https://github.com/user-attachments/assets/0b752ce1-502e-4cfa-be4d-2c14d9f1b1f5)

### To-be

將各種俄羅斯套娃的物品皆計入持有總量，如下:

- "手提袋 > 藍色大桶 > 沙丁魚" 此處的沙丁魚數量也算入持有總量
![neat_after](https://github.com/user-attachments/assets/8a8028e0-9a1b-4974-8ca6-a5f32b82a671)

---
測試存檔: [neat_items.zip](https://github.com/user-attachments/files/23286013/neat_items.zip)
